### PR TITLE
Allow overriding os_family in rbe_autoconfig

### DIFF
--- a/rules/rbe_repo.bzl
+++ b/rules/rbe_repo.bzl
@@ -811,6 +811,11 @@ _rbe_autoconfig = repository_rule(
                    "JAVA_HOME env var from the container. If that is not set, the rule " +
                    "will fail."),
         ),
+        "os_family": attr.string(
+            doc = ("Optional. The os_family to generate the config for. For example, " +
+                   "Linux or Windows (Mac OS X is not supported at this time). The default is " +
+                   "OS Bazel runs on."),
+        ),
         "registry": attr.string(
             doc = ("Optional. The registry to pull the container from. For example, " +
                    "marketplace.gcr.io. The default is the value for the selected " +
@@ -899,6 +904,7 @@ def rbe_autoconfig(
         exec_properties = None,
         export_configs = False,
         java_home = None,
+        os_family = None,
         tag = None,
         toolchain_config_suite_spec = default_toolchain_config_suite_spec(),
         registry = None,
@@ -1195,6 +1201,7 @@ def rbe_autoconfig(
         exec_properties = exec_properties,
         export_configs = export_configs,
         java_home = java_home,
+        os_family = os_family,
         toolchain_config_suite_spec = toolchain_config_suite_spec_stripped,
         registry = registry,
         repository = repository,

--- a/rules/rbe_repo/util.bzl
+++ b/rules/rbe_repo/util.bzl
@@ -144,6 +144,8 @@ def os_family(ctx):
     Returns:
       Returns the name of the OS Family
     """
+    if ctx.attr.os_family:
+      return ctx.attr.os_family
     os_name = ctx.os.name.lower()
     if os_name.find("windows") != -1:
         return "Windows"


### PR DESCRIPTION
Provides a workaround for https://github.com/bazelbuild/bazel-toolchains/issues/895.

Use like this:
rbe_autoconfig(
    name = "engflow_remote_config",
    os_family = "Linux",
    java_home = "/usr/lib/jvm/11.29.3-ca-jdk11.0.2/reduced",
    use_checked_in_confs = "Force",
)